### PR TITLE
Add legend flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           docker run \
             --workdir /workspace \
             --volume "$(pwd)":/workspace \
-            ghcr.io/patrickhoefler/dockerfilegraph:0.0.0
+            ghcr.io/patrickhoefler/dockerfilegraph:0.0.0 \
             --help
 
       - name: Run the Docker image with -o pdf

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,42 +10,81 @@ jobs:
   container:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.17'
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
 
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: Test with code coverage
-      run: go test ./... -race -covermode=atomic -coverprofile=coverage.txt
+      - name: Test with code coverage
+        run: go test ./... -race -covermode=atomic -coverprofile=coverage.txt
 
-    - name: Build binaries and Docker image with GoReleaser
-      uses: goreleaser/goreleaser-action@v2
-      with:
-        args: release --snapshot --skip-publish
+      - name: Build binaries and Docker image with GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --snapshot --skip-publish
 
-    - name: Make example directory writable for all users
-      run: chmod -R o+w example
+      - name: Make example directory writable for all users
+        run: chmod -R o+w example
 
-    - name: Run the Docker image without flags
-      run: cd example && docker run --workdir /workspace --mount type=bind,source="$(pwd)",target=/workspace ghcr.io/patrickhoefler/dockerfilegraph:0.0.0
+      - name: Run the Docker image without flags
+        run: |
+          cd example
+          docker run \
+            --workdir /workspace \
+            --volume "$(pwd)":/workspace \
+            ghcr.io/patrickhoefler/dockerfilegraph:0.0.0
 
-    - name: Run the Docker image with --help
-      run: cd example && docker run --workdir /workspace --mount type=bind,source="$(pwd)",target=/workspace ghcr.io/patrickhoefler/dockerfilegraph:0.0.0 --help
+      - name: Run the Docker image with --help
+        run: |
+          cd example
+          docker run \
+            --workdir /workspace \
+            --volume "$(pwd)":/workspace \
+            ghcr.io/patrickhoefler/dockerfilegraph:0.0.0
+            --help
 
-    - name: Run the Docker image with -o pdf
-      run: cd example && docker run --workdir /workspace --mount type=bind,source="$(pwd)",target=/workspace ghcr.io/patrickhoefler/dockerfilegraph:0.0.0 -o pdf
+      - name: Run the Docker image with -o pdf
+        run: |
+          cd example
+          docker run \
+            --workdir /workspace \
+            --volume "$(pwd)":/workspace \
+            ghcr.io/patrickhoefler/dockerfilegraph:0.0.0 \
+            -o pdf
 
-    - name: Run the Docker image with -o png
-      run: cd example && docker run --workdir /workspace --mount type=bind,source="$(pwd)",target=/workspace ghcr.io/patrickhoefler/dockerfilegraph:0.0.0 -o png
+      - name: Run the Docker image with -o png
+        run: |
+          cd example
+          docker run \
+            --workdir /workspace \
+            --volume "$(pwd)":/workspace \
+            ghcr.io/patrickhoefler/dockerfilegraph:0.0.0 \
+            -o png
 
-    - name: Run the Docker image with --output png --dpi 200
-      run: cd example && docker run --workdir /workspace --mount type=bind,source="$(pwd)",target=/workspace ghcr.io/patrickhoefler/dockerfilegraph:0.0.0 --output png --dpi 200
+      - name: Run the Docker image with --output png --dpi 200
+        run: |
+          cd example
+          docker run \
+            --workdir /workspace \
+            --volume "$(pwd)":/workspace \
+            ghcr.io/patrickhoefler/dockerfilegraph:0.0.0 \
+            --output png \
+            --dpi 200
 
-    - name: Upload code coverage
-      uses: codecov/codecov-action@v2
+      - name: Run the Docker image with --legend
+        run: |
+          cd example
+          docker run \
+            --workdir /workspace \
+            --volume "$(pwd)":/workspace \
+            ghcr.io/patrickhoefler/dockerfilegraph:0.0.0 \
+            --legend
+
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v2
 
   native:
     strategy:
@@ -53,43 +92,46 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.17'
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
 
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: Test
-      run: go test ./...
+      - name: Test
+        run: go test ./...
 
-    - name: Build
-      run: go build
+      - name: Build
+        run: go build
 
-    - name: '[macOS] Install graphviz'
-      if: runner.os == 'macOS'
-      run: brew install graphviz
+      - name: '[macOS] Install graphviz'
+        if: runner.os == 'macOS'
+        run: brew install graphviz
 
-    - name: '[Ubuntu] Install graphviz'
-      if: runner.os == 'Linux'
-      run: sudo apt install --no-install-recommends -y graphviz
+      - name: '[Ubuntu] Install graphviz'
+        if: runner.os == 'Linux'
+        run: sudo apt install --no-install-recommends -y graphviz
 
-    - name: '[Windows] Install graphviz'
-      if: runner.os == 'Windows'
-      run: choco install graphviz --no-progress
+      - name: '[Windows] Install graphviz'
+        if: runner.os == 'Windows'
+        run: choco install graphviz --no-progress
 
-    - name: Run the binary without flags
-      run: cd example && ../dockerfilegraph
+      - name: Run the binary without flags
+        run: cd example && ../dockerfilegraph
 
-    - name: Run the binary with --help
-      run: cd example && ../dockerfilegraph --help
+      - name: Run the binary with --help
+        run: cd example && ../dockerfilegraph --help
 
-    - name: Run the binary with -o pdf
-      run: cd example && ../dockerfilegraph -o pdf
+      - name: Run the binary with -o pdf
+        run: cd example && ../dockerfilegraph -o pdf
 
-    - name: Run the binary with -o png
-      run: cd example && ../dockerfilegraph -o png
+      - name: Run the binary with -o png
+        run: cd example && ../dockerfilegraph -o png
 
-    - name: Run the binary with --output png --dpi 200
-      run: cd example && ../dockerfilegraph --output png --dpi 200
+      - name: Run the binary with --output png --dpi 200
+        run: cd example && ../dockerfilegraph --output png --dpi 200
+
+      - name: Run the binary with --legend
+        run: cd example && ../dockerfilegraph --legend

--- a/README.md
+++ b/README.md
@@ -18,9 +18,17 @@ The edges of the graph represent:
 - _COPY --from=..._ dependencies with an empty arrow head
 - _RUN --mount=type=cache,from=..._ dependencies with an empty diamond arrow head
 
+You can add an optional legend to the graph and change the output format and resolution. For all the details, see the [options](#more-options) below.
+
 ## Example Output
 
-![Example graph](https://user-images.githubusercontent.com/547220/120117354-2037a800-c18d-11eb-8750-ce954c5529df.png)
+### Default
+
+![Example output](https://user-images.githubusercontent.com/547220/120117354-2037a800-c18d-11eb-8750-ce954c5529df.png)
+
+### Including a Legend
+
+![Example output including a legend](https://user-images.githubusercontent.com/547220/143328161-dd80b5ef-5960-4023-b74e-e7b28cd31dcb.png)
 
 ## Getting Started
 
@@ -59,7 +67,7 @@ go build
 ### More Options
 
 ```text
-$ dockerfilegraph --help
+❯ dockerfilegraph --help
 dockerfilegraph visualizes your multi-stage Dockerfile.
 It outputs a graph representation of the build process.
 
@@ -69,6 +77,7 @@ Usage:
 Flags:
   -d, --dpi int   Dots per inch of the PNG export (default 96)
   -h, --help      help for dockerfilegraph
+  -l, --legend    Add a legend (default false)
   -o, --output    Output file format. One of: pdf, png (default pdf)
 ```
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 var (
 	// Used for flags.
 	dpi    int
+	legend bool
 	output enum
 
 	rootCmd = &cobra.Command{
@@ -37,7 +38,7 @@ It outputs a graph representation of the build process.`,
 			}
 			defer os.Remove(dotFile.Name())
 
-			dotFileContent := dockerfile2dot.BuildDotFile(dockerfile)
+			dotFileContent := dockerfile2dot.BuildDotFile(dockerfile, legend)
 
 			_, err = dotFile.Write([]byte(dotFileContent))
 			if err != nil {
@@ -89,6 +90,14 @@ func init() {
 		"d",
 		96, // the default dpi setting of Graphviz
 		"Dots per inch of the PNG export",
+	)
+
+	rootCmd.Flags().BoolVarP(
+		&legend,
+		"legend",
+		"l",
+		false,
+		"Add a legend (default false)",
 	)
 
 	output = newEnum("pdf", "png")

--- a/internal/dockerfile2dot/build.go
+++ b/internal/dockerfile2dot/build.go
@@ -5,12 +5,45 @@ import (
 )
 
 // BuildDotFile builds a GraphViz .dot file from a Google Cloud Build configuration
-func BuildDotFile(simplifiedDockerfile SimplifiedDockerfile) string {
+func BuildDotFile(simplifiedDockerfile SimplifiedDockerfile, legend bool) string {
 	graph := gographviz.NewEscape()
 	graph.SetName("G")
 	graph.SetDir(true)
 	graph.AddAttr("G", "rankdir", "LR")
 	graph.AddAttr("G", "nodesep", "1")
+
+	if legend {
+		graph.AddSubGraph("G", "cluster_legend", nil)
+
+		graph.AddNode("cluster_legend", "key",
+			map[string]string{
+				"shape":    "plaintext",
+				"fontname": "monospace",
+				"fontsize": "10",
+				"label": `<<table border="0" cellpadding="2" cellspacing="0" cellborder="0">
+      <tr><td align="right" port="i0">FROM&nbsp;...&nbsp;</td></tr>
+      <tr><td align="right" port="i1">COPY --from=...&nbsp;</td></tr>
+      <tr><td align="right" port="i2">RUN --mount=type=cache,from=...&nbsp;</td></tr>
+      </table>>`,
+			},
+		)
+		graph.AddNode("cluster_legend", "key2",
+			map[string]string{
+				"shape":    "plaintext",
+				"fontname": "monospace",
+				"fontsize": "10",
+				"label": `<<table border="0" cellpadding="2" cellspacing="0" cellborder="0">
+					<tr><td port="i0">&nbsp;</td></tr>
+					<tr><td port="i1">&nbsp;</td></tr>
+					<tr><td port="i2">&nbsp;</td></tr>
+					</table>>`,
+			},
+		)
+
+		graph.AddPortEdge("key", "i0:e", "key2", "i0:w", true, nil)
+		graph.AddPortEdge("key", "i1:e", "key2", "i1:w", true, map[string]string{"arrowhead": "empty"})
+		graph.AddPortEdge("key", "i2:e", "key2", "i2:w", true, map[string]string{"arrowhead": "ediamond"})
+	}
 
 	for _, baseImage := range simplifiedDockerfile.BaseImages {
 		graph.AddNode("G", "\""+baseImage.ID+"\"", map[string]string{

--- a/internal/dockerfile2dot/build_test.go
+++ b/internal/dockerfile2dot/build_test.go
@@ -1,0 +1,50 @@
+package dockerfile2dot
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildDotFile(t *testing.T) {
+	type args struct {
+		simplifiedDockerfile SimplifiedDockerfile
+		legend               bool
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantContains string
+	}{
+		{
+			name: "simple test",
+			args: args{
+				simplifiedDockerfile: SimplifiedDockerfile{
+					BaseImages: []BaseImage{
+						{ID: "build"},
+						{ID: "release"},
+					},
+					Stages: []Stage{
+						{
+							ID: "release",
+							WaitFor: []WaitFor{
+								{
+									ID:   "build",
+									Type: waitForType(from),
+								},
+							},
+						},
+					},
+				},
+				legend: true,
+			},
+			wantContains: "release",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BuildDotFile(tt.args.simplifiedDockerfile, tt.args.legend); !strings.Contains(got, tt.wantContains) {
+				t.Errorf("BuildDotFile() = %v, did not contain %v", got, tt.wantContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #46 

## Update help text

```
dockerfilegraph visualizes your multi-stage Dockerfile.
It outputs a graph representation of the build process.

Usage:
  dockerfilegraph [flags]

Flags:
  -d, --dpi int   Dots per inch of the PNG export (default 96)
  -h, --help      help for dockerfilegraph
  -l, --legend    Add a legend (default false)
  -o, --output    Output file format. One of: pdf, png (default pdf)
```

## Preview

![Dockerfile](https://user-images.githubusercontent.com/547220/143328161-dd80b5ef-5960-4023-b74e-e7b28cd31dcb.png)

