### PR TITLE
Layer dependencies and cleanup

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,13 +4,14 @@ linters:
     - gofmt
     - govet
     - ineffassign
+    - lll
     - misspell
     - revive
     - staticcheck
 
 linters-settings:
   gocyclo:
-    min-complexity: 15
+    min-complexity: 16
 
 issues:
   include:

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -89,7 +89,7 @@ It outputs a graph representation of the build process.`,
 				os.Exit(1)
 			}
 
-			fmt.Fprintf(dfgWriter, "Successfully created %s", filename)
+			fmt.Fprintf(dfgWriter, "Successfully created %s\n", filename)
 
 			return
 		},

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -77,7 +77,7 @@ It outputs a graph representation of the build process.
 		},
 		{
 			name:    "no args",
-			wantOut: "Successfully created Dockerfile.pdf",
+			wantOut: "Successfully created Dockerfile.pdf\n",
 		},
 		{
 			name:              "empty Dockerfile",
@@ -89,7 +89,7 @@ It outputs a graph representation of the build process.
 		{
 			name:        "output flag canon",
 			cliArgs:     []string{"--output", "canon"},
-			wantOut:     "Successfully created Dockerfile.canon",
+			wantOut:     "Successfully created Dockerfile.canon\n",
 			wantOutFile: "Dockerfile.canon",
 			wantOutFileContent: `digraph G {
 	graph [nodesep=1,
@@ -139,31 +139,134 @@ It outputs a graph representation of the build process.
 		{
 			name:        "output flag dot",
 			cliArgs:     []string{"--output", "dot"},
-			wantOut:     "Successfully created Dockerfile.dot",
+			wantOut:     "Successfully created Dockerfile.dot\n",
 			wantOutFile: "Dockerfile.dot",
 		},
 		{
 			name:        "output flag pdf",
 			cliArgs:     []string{"-o", "pdf"},
-			wantOut:     "Successfully created Dockerfile.pdf",
+			wantOut:     "Successfully created Dockerfile.pdf\n",
 			wantOutFile: "Dockerfile.pdf",
 		},
 		{
 			name:        "output flag png",
 			cliArgs:     []string{"--output", "png"},
-			wantOut:     "Successfully created Dockerfile.png",
+			wantOut:     "Successfully created Dockerfile.png\n",
 			wantOutFile: "Dockerfile.png",
 		},
 		{
 			name:        "output flag png with dpi",
 			cliArgs:     []string{"--output", "png", "--dpi", "200"},
-			wantOut:     "Successfully created Dockerfile.png",
+			wantOut:     "Successfully created Dockerfile.png\n",
 			wantOutFile: "Dockerfile.png",
+		},
+		{
+			name:        "layers flag",
+			cliArgs:     []string{"--layers", "-o", "canon"},
+			wantOut:     "Successfully created Dockerfile.canon\n",
+			wantOutFile: "Dockerfile.canon",
+			wantOutFileContent: `digraph G {
+	graph [nodesep=0.03,
+		rankdir=LR
+	];
+	node [label="\N"];
+	subgraph cluster_0 {
+		graph [label=ubuntu,
+			style=rounded
+		];
+		0	[label=ubuntu,
+			shape=Mrecord,
+			style=invis,
+			width=2];
+		stage_0_layer_0	[label="FROM...",
+			shape=Mrecord,
+			style=dashed,
+			width=2];
+		stage_0_layer_1	[label="RUN...",
+			shape=Mrecord,
+			style=dashed,
+			width=2];
+	}
+	subgraph cluster_1 {
+		graph [label=build,
+			style=rounded
+		];
+		1	[label=build,
+			shape=Mrecord,
+			style=invis,
+			width=2];
+		stage_1_layer_0	[label="FROM...",
+			shape=Mrecord,
+			style=dashed,
+			width=2];
+		stage_1_layer_1	[label="RUN...",
+			shape=Mrecord,
+			style=dashed,
+			width=2];
+	}
+	subgraph cluster_2 {
+		graph [label=release,
+			style=rounded
+		];
+		2	[fillcolor=grey90,
+			label=release,
+			shape=Mrecord,
+			style=invis,
+			width=2];
+		stage_2_layer_0	[fillcolor=grey90,
+			label="FROM...",
+			shape=Mrecord,
+			style=dashed,
+			width=2];
+		stage_2_layer_1	[fillcolor=grey90,
+			label="COPY...",
+			shape=Mrecord,
+			style=dashed,
+			width=2];
+		stage_2_layer_2	[fillcolor=grey90,
+			label="COPY...",
+			shape=Mrecord,
+			style=dashed,
+			width=2];
+		stage_2_layer_3	[fillcolor=grey90,
+			label="ENTRYPOINT...",
+			shape=Mrecord,
+			style=dashed,
+			width=2];
+	}
+	"ubuntu:latest"	[color=grey20,
+		fontcolor=grey20,
+		shape=Mrecord,
+		style=dashed,
+		width=2];
+	"ubuntu:latest" -> 0;
+	0 -> 2	[arrowhead=empty];
+	"golang:1.18"	[color=grey20,
+		fontcolor=grey20,
+		shape=Mrecord,
+		style=dashed,
+		width=2];
+	"golang:1.18" -> 1;
+	1 -> 2	[arrowhead=empty];
+	buildcache	[color=grey20,
+		fontcolor=grey20,
+		shape=Mrecord,
+		style=dashed,
+		width=2];
+	buildcache -> 1	[arrowhead=ediamond];
+	scratch	[color=grey20,
+		fontcolor=grey20,
+		shape=Mrecord,
+		style=dashed,
+		width=2];
+	scratch -> 2;
+}
+`,
 		},
 		{
 			name:        "legend flag",
 			cliArgs:     []string{"--legend", "-o", "canon"},
-			wantOut:     "Successfully created Dockerfile.canon",
+			wantOut:     "Successfully created Dockerfile.canon\n",
 			wantOutFile: "Dockerfile.canon",
 			wantOutFileContent: `digraph G {
 	graph [nodesep=1,

--- a/internal/dockerfile2dot/build_test.go
+++ b/internal/dockerfile2dot/build_test.go
@@ -26,11 +26,15 @@ func TestBuildDotFile(t *testing.T) {
 					},
 					Stages: []Stage{
 						{
-							ID: "release",
-							WaitFor: []WaitFor{
+							ID: "0",
+							Layers: []Layer{
 								{
-									ID:   "build",
-									Type: waitForType(from),
+									ID:   "0",
+									Name: "FROM...",
+									WaitFor: WaitFor{
+										ID:   "build",
+										Type: waitForType(from),
+									},
 								},
 							},
 						},
@@ -44,7 +48,9 @@ func TestBuildDotFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := BuildDotFile(tt.args.simplifiedDockerfile, tt.args.legend, tt.args.layers); !strings.Contains(got, tt.wantContains) {
+			if got := BuildDotFile(
+				tt.args.simplifiedDockerfile, tt.args.legend, tt.args.layers,
+			); !strings.Contains(got, tt.wantContains) {
 				t.Errorf("BuildDotFile() = %v, did not contain %v", got, tt.wantContains)
 			}
 		})

--- a/internal/dockerfile2dot/load.go
+++ b/internal/dockerfile2dot/load.go
@@ -7,19 +7,15 @@ import (
 	"github.com/spf13/afero"
 )
 
-// LoadAndParseDockerfile looks for the Dockerfile and returns a SimplifiedDockerfile
+// LoadAndParseDockerfile looks for the Dockerfile and returns a
+// SimplifiedDockerfile.
 func LoadAndParseDockerfile(inputFS afero.Fs) (SimplifiedDockerfile, error) {
-	for _, filename := range []string{"Dockerfile"} {
-		content, err := afero.ReadFile(inputFS, filename)
-		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				continue
-			} else {
-				panic(err)
-			}
+	content, err := afero.ReadFile(inputFS, "Dockerfile")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return SimplifiedDockerfile{}, errors.New("could not find any Dockerfile in the current working directory")
 		}
-		return dockerfileToSimplifiedDockerfile(content)
+		panic(err)
 	}
-
-	return SimplifiedDockerfile{}, errors.New("could not find any Dockerfile in the current working directory")
+	return dockerfileToSimplifiedDockerfile(content)
 }

--- a/internal/dockerfile2dot/load_test.go
+++ b/internal/dockerfile2dot/load_test.go
@@ -1,0 +1,65 @@
+package dockerfile2dot
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/afero"
+)
+
+func TestLoadAndParseDockerfile(t *testing.T) {
+	type args struct {
+		inputFS afero.Fs
+	}
+
+	dockerfileFS := afero.NewMemMapFs()
+	_ = afero.WriteFile(dockerfileFS, "Dockerfile", []byte(`FROM scratch`), 0644)
+
+	tests := []struct {
+		name    string
+		args    args
+		want    SimplifiedDockerfile
+		wantErr bool
+	}{
+		{
+			name: "no Dockerfile found",
+			args: args{
+				inputFS: afero.NewMemMapFs(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Dockerfile found",
+			args: args{
+				inputFS: dockerfileFS,
+			},
+			want: SimplifiedDockerfile{
+				BaseImages: []BaseImage{{ID: "scratch"}},
+				Stages: []Stage{
+					{
+						ID: "0",
+						Layers: []Layer{
+							{
+								ID:      "0",
+								Name:    "FROM...",
+								WaitFor: WaitFor{ID: "scratch", Type: waitForType(from)}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LoadAndParseDockerfile(tt.args.inputFS)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadAndParseDockerfile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("LoadAndParseDockerfile() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/dockerfile2dot/structs.go
+++ b/internal/dockerfile2dot/structs.go
@@ -1,29 +1,34 @@
 package dockerfile2dot
 
 // SimplifiedDockerfile contains the parts of the Dockerfile
-// that are relevant for generating the multi-stage build graph
+// that are relevant for generating the multi-stage build graph.
 type SimplifiedDockerfile struct {
-	BaseImages     []BaseImage
-	Stages         []Stage
-	LayersNotStage []Layer
+	// External base images
+	BaseImages []BaseImage
+	// Args set before the first stage, see
+	// https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+	BeforeFirstStage []Layer
+	// Build stages
+	Stages []Stage
 }
 
 // Stage contains the parts of a single build stage within a multi-stage Dockerfile
-// that are relevant for generating the multi-stage build graph
+// that are relevant for generating the multi-stage build graph.
 type Stage struct {
-	ID      string    // numeric index based on the order of appearance in the Dockerfile
-	Name    string    // the part after the AS in the FROM line
-	WaitFor []WaitFor // dependencies of the stage
-	Layers  []Layer   // layers per stage
+	ID     string  // numeric index based on the order of appearance in the Dockerfile
+	Name   string  // the part after the AS in the FROM line
+	Layers []Layer // layers per stage
 }
 
-// Layer stores the changes compared to the image it’s based on within a multi-stage Dockerfile
+// Layer stores the changes compared to the image it’s based on within a
+// multi-stage Dockerfile.
 type Layer struct {
-	ID   string // numeric index based on the order of appearance in the stage
-	Name string // display the command store in the layer
+	ID      string  // numeric index based on the order of appearance in the stage
+	Name    string  // the command and truncated args
+	WaitFor WaitFor // stage or external base image for which this layer needs to wait
 }
 
-// BaseImage contains the ID of an external base images that a build stage depends on
+// BaseImage contains the ID of an external base image used for dependencies.
 type BaseImage struct {
 	ID string // full repo:tag@sha
 }
@@ -40,5 +45,5 @@ const (
 // has to wait for and the type, i.e. the reason why it has to wait for it
 type WaitFor struct {
 	ID   string      // the ID of the base image or stage
-	Type waitForType // either "from" or "copy"
+	Type waitForType // one of "from", "copy" or "runMountTypeCache"
 }


### PR DESCRIPTION
This PR refactors the code to store `waitFor` dependencies — i.e. the edges in the graph — per layer instead per stage.

Also, cleanup.