### PR TITLE
Use box,style=rounded instead of Mrecord

### DIFF
--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -111,42 +111,44 @@ It outputs a graph representation of the build process.
 	external_image_0	[color=grey20,
 		fontcolor=grey20,
 		label="ubuntu:latest",
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	stage_0	[label=ubuntu,
-		shape=Mrecord,
+		shape=box,
+		style=rounded,
 		width=2];
 	external_image_0 -> stage_0;
 	stage_2	[fillcolor=grey90,
 		label=release,
-		shape=Mrecord,
-		style=filled,
+		shape=box,
+		style="filled,rounded",
 		width=2];
 	stage_0 -> stage_2	[arrowhead=empty];
 	external_image_1	[color=grey20,
 		fontcolor=grey20,
 		label="golang:1.19",
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	stage_1	[label=build,
-		shape=Mrecord,
+		shape=box,
+		style=rounded,
 		width=2];
 	external_image_1 -> stage_1;
 	stage_1 -> stage_2	[arrowhead=empty];
 	external_image_2	[color=grey20,
 		fontcolor=grey20,
 		label=buildcache,
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	external_image_2 -> stage_1	[arrowhead=ediamond];
 	external_image_3	[color=grey20,
 		fontcolor=grey20,
 		label=scratch,
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	external_image_3 -> stage_2;
 }
@@ -194,14 +196,14 @@ It outputs a graph representation of the build process.
 		stage_0_layer_0	[fillcolor=white,
 			label="FROM ubuntu:lates...",
 			penwidth=0.5,
-			shape=Mrecord,
-			style=filled,
+			shape=box,
+			style="filled,rounded",
 			width=2];
 		stage_0_layer_1	[fillcolor=white,
 			label="RUN   apt-get upd...",
 			penwidth=0.5,
-			shape=Mrecord,
-			style=filled,
+			shape=box,
+			style="filled,rounded",
 			width=2];
 		stage_0_layer_0 -> stage_0_layer_1;
 	}
@@ -212,14 +214,14 @@ It outputs a graph representation of the build process.
 		stage_1_layer_0	[fillcolor=white,
 			label="FROM golang:1.19 ...",
 			penwidth=0.5,
-			shape=Mrecord,
-			style=filled,
+			shape=box,
+			style="filled,rounded",
 			width=2];
 		stage_1_layer_1	[fillcolor=white,
 			label="RUN --mount=type=...",
 			penwidth=0.5,
-			shape=Mrecord,
-			style=filled,
+			shape=box,
+			style="filled,rounded",
 			width=2];
 		stage_1_layer_0 -> stage_1_layer_1;
 	}
@@ -232,28 +234,28 @@ It outputs a graph representation of the build process.
 		stage_2_layer_0	[fillcolor=white,
 			label="FROM scratch AS r...",
 			penwidth=0.5,
-			shape=Mrecord,
-			style=filled,
+			shape=box,
+			style="filled,rounded",
 			width=2];
 		stage_2_layer_1	[fillcolor=white,
 			label="COPY --from=ubunt...",
 			penwidth=0.5,
-			shape=Mrecord,
-			style=filled,
+			shape=box,
+			style="filled,rounded",
 			width=2];
 		stage_2_layer_0 -> stage_2_layer_1;
 		stage_2_layer_2	[fillcolor=white,
 			label="COPY --from=build...",
 			penwidth=0.5,
-			shape=Mrecord,
-			style=filled,
+			shape=box,
+			style="filled,rounded",
 			width=2];
 		stage_2_layer_1 -> stage_2_layer_2;
 		stage_2_layer_3	[fillcolor=white,
 			label="ENTRYPOINT ['/exa...",
 			penwidth=0.5,
-			shape=Mrecord,
-			style=filled,
+			shape=box,
+			style="filled,rounded",
 			width=2];
 		stage_2_layer_2 -> stage_2_layer_3;
 	}
@@ -262,8 +264,8 @@ It outputs a graph representation of the build process.
 	external_image_0	[color=grey20,
 		fontcolor=grey20,
 		label="ubuntu:latest",
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	external_image_0 -> stage_0_layer_0;
 	stage_1_layer_1 -> stage_2_layer_2	[arrowhead=empty,
@@ -271,22 +273,22 @@ It outputs a graph representation of the build process.
 	external_image_1	[color=grey20,
 		fontcolor=grey20,
 		label="golang:1.19",
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	external_image_1 -> stage_1_layer_0;
 	external_image_2	[color=grey20,
 		fontcolor=grey20,
 		label=buildcache,
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	external_image_2 -> stage_1_layer_1	[arrowhead=ediamond];
 	external_image_3	[color=grey20,
 		fontcolor=grey20,
 		label=scratch,
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	external_image_3 -> stage_2_layer_0;
 }
@@ -327,42 +329,44 @@ It outputs a graph representation of the build process.
 	external_image_0	[color=grey20,
 		fontcolor=grey20,
 		label="ubuntu:latest",
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	stage_0	[label=ubuntu,
-		shape=Mrecord,
+		shape=box,
+		style=rounded,
 		width=2];
 	external_image_0 -> stage_0;
 	stage_2	[fillcolor=grey90,
 		label=release,
-		shape=Mrecord,
-		style=filled,
+		shape=box,
+		style="filled,rounded",
 		width=2];
 	stage_0 -> stage_2	[arrowhead=empty];
 	external_image_1	[color=grey20,
 		fontcolor=grey20,
 		label="golang:1.19",
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	stage_1	[label=build,
-		shape=Mrecord,
+		shape=box,
+		style=rounded,
 		width=2];
 	external_image_1 -> stage_1;
 	stage_1 -> stage_2	[arrowhead=empty];
 	external_image_2	[color=grey20,
 		fontcolor=grey20,
 		label=buildcache,
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	external_image_2 -> stage_1	[arrowhead=ediamond];
 	external_image_3	[color=grey20,
 		fontcolor=grey20,
 		label=scratch,
-		shape=Mrecord,
-		style=dashed,
+		shape=box,
+		style="dashed,rounded",
 		width=2];
 	external_image_3 -> stage_2;
 }

--- a/internal/dockerfile2dot/build.go
+++ b/internal/dockerfile2dot/build.go
@@ -38,9 +38,9 @@ func BuildDotFile(
 			fmt.Sprintf("external_image_%d", externalImageIndex),
 			map[string]string{
 				"label":     "\"" + label + "\"",
-				"shape":     "Mrecord",
+				"shape":     "box",
 				"width":     "2",
-				"style":     "dashed",
+				"style":     "\"dashed,rounded\"",
 				"color":     "grey20",
 				"fontcolor": "grey20",
 			},
@@ -50,7 +50,8 @@ func BuildDotFile(
 	for stageIndex, stage := range simplifiedDockerfile.Stages {
 		attrs := map[string]string{
 			"label": "\"" + getStageLabel(stageIndex, stage) + "\"",
-			"shape": "Mrecord",
+			"shape": "box",
+			"style": "rounded",
 			"width": "2",
 		}
 
@@ -58,7 +59,7 @@ func BuildDotFile(
 		if !layers {
 			// Color the last stage, because it is the default build target
 			if stageIndex == len(simplifiedDockerfile.Stages)-1 {
-				attrs["style"] = "filled"
+				attrs["style"] = "\"filled,rounded\""
 				attrs["fillcolor"] = "grey90"
 			}
 
@@ -84,7 +85,7 @@ func BuildDotFile(
 			for layerIndex, layer := range stage.Layers {
 				attrs["label"] = "\"" + layer.Label + "\""
 				attrs["penwidth"] = "0.5"
-				attrs["style"] = "filled"
+				attrs["style"] = "\"filled,rounded\""
 				attrs["fillcolor"] = "white"
 				_ = graph.AddNode(
 					cluster,
@@ -122,7 +123,8 @@ func BuildDotFile(
 					fmt.Sprintf("before_first_stage_%d", argIndex),
 					map[string]string{
 						"label": arg.Label,
-						"shape": "Mrecord",
+						"shape": "box",
+						"style": "rounded",
 						"width": "2",
 					},
 				)


### PR DESCRIPTION
Fixes #171 

One subtle difference: it appears `Mrecord` collapses adjacent spaces, so there are now two spaces between `RUN` and `apt` in the layers example.
 
![Dockerfile](https://user-images.githubusercontent.com/2285761/194721021-c6e93361-8640-460b-9ff6-367d3fb96d6b.png)
