### PR TITLE
feat: add --separate-scratch flag

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,18 @@
+# GitHub Copilot Custom Instructions
+
+## Testing Guidelines
+
+- **No temporary test files**: Never create standalone test files like "test-*.dockerfile", "quick-test.*", etc.
+- **Use existing test suites**: Add proper test cases to existing test files in the appropriate `*_test.go` files
+- **Follow test patterns**: Use the established testing patterns in the codebase (table-driven tests, proper assertions)
+- **Clean testing**: If testing is needed, extend the existing test suite rather than creating throwaway files
+- **Focus on correct behavior**: Tests should verify expected functionality, not document bugs or regressions
+- **Positive test naming**: Name tests to describe what they verify (e.g., `Test_separateScratchConnections`) rather than what's broken
+- **Clear test comments**: Comments should explain what behavior is being tested, not reference historical issues
+
+## Code Quality
+
+- Follow the existing code style and patterns
+- Use proper error handling
+- Write comprehensive tests for new functionality
+- Maintain backward compatibility unless explicitly breaking changes are needed

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ build-docker-image-ubuntu: build-linux
 build-linux: clean
 	CGO_ENABLED=0 GOOS=linux go build $(FLAGS)
 
+check: lint test
+
 clean:
 	go clean
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Flags:
   -n, --nodesep float           minimum space between two adjacent nodes in the same rank (default 1)
   -o, --output                  output file format, one of: canon, dot, pdf, png, raw, svg (default pdf)
   -r, --ranksep float           minimum separation between ranks (default 0.5)
+      --separate-scratch        create separate nodes for each scratch image instead of collapsing them
   -u, --unflatten uint          stagger length of leaf edges between [1,u] (default 0)
       --version                 display the version of dockerfilegraph
 ```

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,18 +15,19 @@ import (
 )
 
 var (
-	concentrateFlag    bool
-	dpiFlag            uint
-	edgestyleFlag      enum
-	filenameFlag       string
-	layersFlag         bool
-	legendFlag         bool
-	maxLabelLengthFlag uint
-	nodesepFlag        float64
-	outputFlag         enum
-	ranksepFlag        float64
-	unflattenFlag      uint
-	versionFlag        bool
+	concentrateFlag     bool
+	dpiFlag             uint
+	edgestyleFlag       enum
+	filenameFlag        string
+	layersFlag          bool
+	legendFlag          bool
+	maxLabelLengthFlag  uint
+	nodesepFlag         float64
+	outputFlag          enum
+	ranksepFlag         float64
+	separateScratchFlag bool
+	unflattenFlag       uint
+	versionFlag         bool
 )
 
 // dfgWriter is a writer that prints to stdout. When testing, we
@@ -67,6 +68,7 @@ It creates a visual graph representation of the build process.`,
 				inputFS,
 				filenameFlag,
 				int(maxLabelLengthFlag),
+				separateScratchFlag,
 			)
 			if err != nil {
 				return
@@ -225,6 +227,13 @@ It creates a visual graph representation of the build process.`,
 		"r",
 		0.5,
 		"minimum separation between ranks",
+	)
+
+	rootCmd.Flags().BoolVar(
+		&separateScratchFlag,
+		"separate-scratch",
+		false,
+		"create separate nodes for each scratch image instead of collapsing them",
 	)
 
 	rootCmd.Flags().UintVarP(

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -38,6 +38,7 @@ Flags:
   -n, --nodesep float           minimum space between two adjacent nodes in the same rank (default 1)
   -o, --output                  output file format, one of: canon, dot, pdf, png, raw, svg (default pdf)
   -r, --ranksep float           minimum separation between ranks (default 0.5)
+      --separate-scratch        create separate nodes for each scratch image instead of collapsing them
   -u, --unflatten uint          stagger length of leaf edges between [1,u] (default 0)
       --version                 display the version of dockerfilegraph
 `
@@ -487,6 +488,28 @@ It creates a visual graph representation of the build process.
 		style="dashed,rounded",
 		width=2];
 	external_image_3 -> stage_2;
+}
+`,
+		},
+		{
+			name:    "separate scratch flag",
+			cliArgs: []string{"--separate-scratch", "-o", "raw"},
+			dockerfileContent: "FROM scratch AS app1\nCOPY app1.txt /app1.txt\n\n" +
+				"FROM scratch AS app2\nCOPY app2.txt /app2.txt\n",
+			wantOut:     "Successfully created Dockerfile.raw\n",
+			wantOutFile: "Dockerfile.raw",
+			wantOutFileContent: `digraph G {
+	compound=true;
+	nodesep=1.00;
+	rankdir=LR;
+	ranksep=0.50;
+	external_image_0->stage_0;
+	external_image_1->stage_1;
+	external_image_0 [ color=grey20, fontcolor=grey20, label="scratch", shape=box, style="dashed,rounded", width=2 ];
+	external_image_1 [ color=grey20, fontcolor=grey20, label="scratch", shape=box, style="dashed,rounded", width=2 ];
+	stage_0 [ label="app1", shape=box, style=rounded, width=2 ];
+	stage_1 [ fillcolor=grey90, label="app2", shape=box, style="filled,rounded", width=2 ];
+
 }
 `,
 		},

--- a/internal/dockerfile2dot/build.go
+++ b/internal/dockerfile2dot/build.go
@@ -169,7 +169,7 @@ func addEdgesForStage(
 			}
 
 			sourceNodeID, additionalEdgeAttrs := getWaitForNodeID(
-				simplifiedDockerfile, waitFor.Name, layers,
+				simplifiedDockerfile, waitFor.ID, layers,
 			)
 			for k, v := range additionalEdgeAttrs {
 				edgeAttrs[k] = v
@@ -287,9 +287,9 @@ func getWaitForNodeID(
 		}
 	}
 
-	// Check if it's an external image name
+	// Check if it's an external image ID
 	for externalImageIndex, externalImage := range simplifiedDockerfile.ExternalImages {
-		if nameOrID == externalImage.Name {
+		if nameOrID == externalImage.ID {
 			nodeID = fmt.Sprintf("external_image_%d", externalImageIndex)
 			return
 		}

--- a/internal/dockerfile2dot/build_test.go
+++ b/internal/dockerfile2dot/build_test.go
@@ -31,8 +31,8 @@ func TestBuildDotFile(t *testing.T) {
 						},
 					},
 					ExternalImages: []ExternalImage{
-						{Name: "build"},
-						{Name: "release"},
+						{ID: "build", Name: "build"},
+						{ID: "release", Name: "release"},
 					},
 					Stages: []Stage{
 						{
@@ -40,7 +40,7 @@ func TestBuildDotFile(t *testing.T) {
 								{
 									Label: "FROM...",
 									WaitFors: []WaitFor{{
-										Name: "build",
+										ID:   "build",
 										Type: waitForType(waitForFrom),
 									}},
 								},
@@ -66,8 +66,8 @@ func TestBuildDotFile(t *testing.T) {
 						},
 					},
 					ExternalImages: []ExternalImage{
-						{Name: "build"},
-						{Name: "release"},
+						{ID: "build", Name: "build"},
+						{ID: "release", Name: "release"},
 					},
 					Stages: []Stage{
 						{
@@ -75,7 +75,7 @@ func TestBuildDotFile(t *testing.T) {
 								{
 									Label: "FROM...",
 									WaitFors: []WaitFor{{
-										Name: "build",
+										ID:   "build",
 										Type: waitForType(waitForFrom),
 									}},
 								},
@@ -90,6 +90,53 @@ func TestBuildDotFile(t *testing.T) {
 				ranksep:        "0.5",
 			},
 			wantContains: "release",
+		},
+		{
+			name: "separate scratch images show correct labels",
+			args: args{
+				simplifiedDockerfile: SimplifiedDockerfile{
+					ExternalImages: []ExternalImage{
+						{ID: "scratch-0", Name: "scratch"},
+						{ID: "scratch-1", Name: "scratch"},
+					},
+					Stages: []Stage{
+						{
+							Name: "app1",
+							Layers: []Layer{
+								{
+									Label: "FROM scratch AS app1",
+									WaitFors: []WaitFor{{
+										ID:   "scratch-0",
+										Type: waitForType(waitForFrom),
+									}},
+								},
+							},
+						},
+						{
+							Name: "app2",
+							Layers: []Layer{
+								{
+									Label: "FROM scratch AS app2",
+									WaitFors: []WaitFor{{
+										ID:   "scratch-1",
+										Type: waitForType(waitForFrom),
+									}},
+								},
+							},
+						},
+					},
+				},
+				concentrate:    false,
+				edgestyle:      "default",
+				layers:         false,
+				legend:         false,
+				maxLabelLength: 20,
+				nodesep:        "0.5",
+				ranksep:        "0.5",
+			},
+			wantContains: `external_image_0 [ color=grey20, fontcolor=grey20, label="scratch", shape=box, ` +
+				`style="dashed,rounded", width=2 ];
+	external_image_1 [ color=grey20, fontcolor=grey20, label="scratch"`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/dockerfile2dot/load.go
+++ b/internal/dockerfile2dot/load.go
@@ -16,6 +16,7 @@ func LoadAndParseDockerfile(
 	inputFS afero.Fs,
 	filename string,
 	maxLabelLength int,
+	separateScratch bool,
 ) (SimplifiedDockerfile, error) {
 	content, err := afero.ReadFile(inputFS, filename)
 	if err != nil {
@@ -28,5 +29,5 @@ func LoadAndParseDockerfile(
 		}
 		panic(err)
 	}
-	return dockerfileToSimplifiedDockerfile(content, maxLabelLength)
+	return dockerfileToSimplifiedDockerfile(content, maxLabelLength, separateScratch)
 }

--- a/internal/dockerfile2dot/structs.go
+++ b/internal/dockerfile2dot/structs.go
@@ -15,33 +15,35 @@ type SimplifiedDockerfile struct {
 // Stage represents a single build stage within the multi-stage Dockerfile or
 // an external image.
 type Stage struct {
-	Name   string  // the part after the AS in the FROM line
-	Layers []Layer // the layers of the stage
+	Name   string  // The part after the AS in the FROM line
+	Layers []Layer // The layers of the stage
 }
 
-// Layer stores the changes compared to the image it’s based on within a
+// Layer stores the changes compared to the image it's based on within a
 // multi-stage Dockerfile.
 type Layer struct {
-	Label    string    // the command and truncated args
-	WaitFors []WaitFor // stages or external images for which this layer needs to wait
+	Label    string    // The command and truncated args
+	WaitFors []WaitFor // Stages or external images for which this layer needs to wait
 }
 
 // ExternalImage holds the name of an external image.
 type ExternalImage struct {
-	Name string
+	ID   string // Unique identifier for this external image instance
+	Name string // The original name of the external image
 }
 
+// waitForType represents the type of dependency between stages or images.
 type waitForType int
 
 const (
-	waitForCopy waitForType = iota
-	waitForFrom
-	waitForMount
+	waitForCopy  waitForType = iota // COPY dependency from another stage
+	waitForFrom                     // FROM dependency on another stage or image
+	waitForMount                    // MOUNT dependency for build cache
 )
 
 // WaitFor holds the name of the stage or external image for which the builder
-// has to wait, and the type, i.e. the reason why it has to wait for it
+// has to wait, and the type, i.e. the reason why it has to wait for it.
 type WaitFor struct {
-	Name string      // the name of the stage or external image for which the builder has to wait
-	Type waitForType // the reason why it has to wait
+	ID   string      // The unique identifier of the stage or external image for which the builder has to wait
+	Type waitForType // The reason why it has to wait
 }


### PR DESCRIPTION
This pull request introduces several updates to enhance functionality, improve testing practices, and refactor the codebase for better maintainability. The key changes include adding a new `--separate-scratch` flag for graph generation, updating testing guidelines, and refactoring the handling of external images in Dockerfile parsing.

### New Feature: `--separate-scratch` Flag
* Added a `--separate-scratch` flag to create separate nodes for each scratch image in the graph instead of collapsing them. This includes updates to `internal/cmd/root.go`, `README.md`, and associated tests (`internal/cmd/root_test.go`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R157) [[2]](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dR28) [[3]](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dR71) [[4]](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dR232-R238) [[5]](diffhunk://#diff-6cb8801f5c168d1ee5c238a5dafdc893250f6bb23569d53d423c8a9d15121af1R41) [[6]](diffhunk://#diff-6cb8801f5c168d1ee5c238a5dafdc893250f6bb23569d53d423c8a9d15121af1R492-R513)

### Refactoring: External Image Handling
* Refactored the `dockerfileToSimplifiedDockerfile` function to use unique IDs (`ID`) instead of names (`Name`) for external images. This affects various files, including `internal/dockerfile2dot/convert.go`, `internal/dockerfile2dot/build.go`, and their respective test files. [[1]](diffhunk://#diff-1f1d98e789c5111c50869632c1387511e26f6c44ef359a358cb14ee6ca6ef31bL94-R96) [[2]](diffhunk://#diff-1f1d98e789c5111c50869632c1387511e26f6c44ef359a358cb14ee6ca6ef31bL113-R115) [[3]](diffhunk://#diff-1f1d98e789c5111c50869632c1387511e26f6c44ef359a358cb14ee6ca6ef31bL135-R137) [[4]](diffhunk://#diff-8927fba13fe5d1ea0a3680ed46fb141a5f921a27ed639fa6953eef7aba1a0f3aL172-R172) [[5]](diffhunk://#diff-8927fba13fe5d1ea0a3680ed46fb141a5f921a27ed639fa6953eef7aba1a0f3aL290-R292) [[6]](diffhunk://#diff-3b9030fcb2b7529fa305d4d3681bd177b762b76f3178f6bd29f81b36d07fe165L34-R43)

### Testing Improvements
* Introduced comprehensive tests for the new `--separate-scratch` flag and updated existing tests to reflect the refactored external image handling. [[1]](diffhunk://#diff-da1cd2cc32fbc3ded7455550e185218b6095f1458abb49c64b850de36078388dR14) [[2]](diffhunk://#diff-da1cd2cc32fbc3ded7455550e185218b6095f1458abb49c64b850de36078388dR55-R85) [[3]](diffhunk://#diff-da1cd2cc32fbc3ded7455550e185218b6095f1458abb49c64b850de36078388dR103-R123) [[4]](diffhunk://#diff-da1cd2cc32fbc3ded7455550e185218b6095f1458abb49c64b850de36078388dL139-R155) [[5]](diffhunk://#diff-da1cd2cc32fbc3ded7455550e185218b6095f1458abb49c64b850de36078388dL180-R195) [[6]](diffhunk://#diff-da1cd2cc32fbc3ded7455550e185218b6095f1458abb49c64b850de36078388dL204-R208)

### Documentation Updates
* Added testing guidelines and code quality standards in `.github/copilot-instructions.md` to ensure consistency and maintainability.
* Updated `README.md` to document the new `--separate-scratch` flag.

### Build System Enhancement
* Added a `check` target to the `Makefile` to run linting and tests in a single command.