### PR TITLE
feat: refactor flag for displaying scratch images

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,13 +2,18 @@
 
 ## Testing Guidelines
 
+- **TDD Approach**: Follow Red-Green-Refactor cycle for all new features
+  - **Red**: Write failing tests first that describe the desired behavior
+  - **Green**: Write minimal code to make tests pass
+  - **Refactor**: Clean up code while keeping all tests passing
 - **No temporary test files**: Never create standalone test files like "test-*.dockerfile", "quick-test.*", etc.
 - **Use existing test suites**: Add proper test cases to existing test files in the appropriate `*_test.go` files
 - **Follow test patterns**: Use the established testing patterns in the codebase (table-driven tests, proper assertions)
 - **Clean testing**: If testing is needed, extend the existing test suite rather than creating throwaway files
 - **Focus on correct behavior**: Tests should verify expected functionality, not document bugs or regressions
-- **Positive test naming**: Name tests to describe what they verify (e.g., `Test_separateScratchConnections`) rather than what's broken
+- **Test naming**: Name tests to describe what they verify (e.g., `Test_separateScratchConnections`) rather than what's broken
 - **Clear test comments**: Comments should explain what behavior is being tested, not reference historical issues
+- **Comprehensive coverage**: Ensure edge cases, error conditions, and integration scenarios are tested
 
 ## Code Quality
 
@@ -16,3 +21,4 @@
 - Use proper error handling
 - Write comprehensive tests for new functionality
 - Maintain backward compatibility unless explicitly breaking changes are needed
+- Always use `make check` for efficient linting and testing - it runs golangci-lint, tests with coverage, and enforces code quality standards in one command

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Flags:
   -n, --nodesep float           minimum space between two adjacent nodes in the same rank (default 1)
   -o, --output                  output file format, one of: canon, dot, pdf, png, raw, svg (default pdf)
   -r, --ranksep float           minimum separation between ranks (default 0.5)
-      --separate-scratch        create separate nodes for each scratch image instead of collapsing them
+      --scratch                 how to handle scratch images, one of: collapsed, hidden, separated (default collapsed)
   -u, --unflatten uint          stagger length of leaf edges between [1,u] (default 0)
       --version                 display the version of dockerfilegraph
 ```

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,19 +15,19 @@ import (
 )
 
 var (
-	concentrateFlag     bool
-	dpiFlag             uint
-	edgestyleFlag       enum
-	filenameFlag        string
-	layersFlag          bool
-	legendFlag          bool
-	maxLabelLengthFlag  uint
-	nodesepFlag         float64
-	outputFlag          enum
-	ranksepFlag         float64
-	separateScratchFlag bool
-	unflattenFlag       uint
-	versionFlag         bool
+	concentrateFlag    bool
+	dpiFlag            uint
+	edgestyleFlag      enum
+	filenameFlag       string
+	layersFlag         bool
+	legendFlag         bool
+	maxLabelLengthFlag uint
+	nodesepFlag        float64
+	outputFlag         enum
+	ranksepFlag        float64
+	scratchFlag        enum
+	unflattenFlag      uint
+	versionFlag        bool
 )
 
 // dfgWriter is a writer that prints to stdout. When testing, we
@@ -63,12 +63,15 @@ It creates a visual graph representation of the build process.`,
 				return
 			}
 
+			// Determine scratch mode from flag
+			scratchMode := scratchFlag.String()
+
 			// Load and parse the Dockerfile.
 			dockerfile, err := dockerfile2dot.LoadAndParseDockerfile(
 				inputFS,
 				filenameFlag,
 				int(maxLabelLengthFlag),
-				separateScratchFlag,
+				scratchMode,
 			)
 			if err != nil {
 				return
@@ -229,11 +232,11 @@ It creates a visual graph representation of the build process.`,
 		"minimum separation between ranks",
 	)
 
-	rootCmd.Flags().BoolVar(
-		&separateScratchFlag,
-		"separate-scratch",
-		false,
-		"create separate nodes for each scratch image instead of collapsing them",
+	scratchFlag = newEnum("collapsed", "separated", "hidden")
+	rootCmd.Flags().Var(
+		&scratchFlag,
+		"scratch",
+		"how to handle scratch images, one of: "+strings.Join(scratchFlag.AllowedValues(), ", "),
 	)
 
 	rootCmd.Flags().UintVarP(

--- a/internal/dockerfile2dot/load.go
+++ b/internal/dockerfile2dot/load.go
@@ -16,7 +16,7 @@ func LoadAndParseDockerfile(
 	inputFS afero.Fs,
 	filename string,
 	maxLabelLength int,
-	separateScratch bool,
+	scratchMode string,
 ) (SimplifiedDockerfile, error) {
 	content, err := afero.ReadFile(inputFS, filename)
 	if err != nil {
@@ -29,5 +29,5 @@ func LoadAndParseDockerfile(
 		}
 		panic(err)
 	}
-	return dockerfileToSimplifiedDockerfile(content, maxLabelLength, separateScratch)
+	return dockerfileToSimplifiedDockerfile(content, maxLabelLength, scratchMode)
 }

--- a/internal/dockerfile2dot/load_test.go
+++ b/internal/dockerfile2dot/load_test.go
@@ -54,8 +54,8 @@ func TestLoadAndParseDockerfile(t *testing.T) {
 			_, err := LoadAndParseDockerfile(
 				tt.args.inputFS,
 				tt.args.filename,
-				20,    // Default maxLabelLength
-				false, // Default separateScratch
+				20,          // Default maxLabelLength
+				"collapsed", // Default scratchMode
 			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LoadAndParseDockerfile() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
This pull request introduces a new `--scratch` flag to replace the `--separate-scratch` flag, enhancing the flexibility of handling scratch images in Dockerfile visualizations. It also updates related documentation and tests to reflect these changes. Additionally, improvements were made to testing guidelines and test coverage.

### Core Feature Update: Scratch Image Handling
* Replaced the `--separate-scratch` flag with the `--scratch` flag, which supports three modes: `collapsed`, `hidden`, and `separated` for handling scratch images (`README.md`, `internal/cmd/root.go`, `internal/dockerfile2dot/convert.go`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L157-R157) [[2]](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dL28-R28) [[3]](diffhunk://#diff-1f1d98e789c5111c50869632c1387511e26f6c44ef359a358cb14ee6ca6ef31bL60-R60)
* Updated the logic in `dockerfileToSimplifiedDockerfile` and related helper functions to handle the three modes of the `--scratch` flag, including skipping scratch images in hidden mode and generating unique IDs for separated mode (`internal/dockerfile2dot/convert.go`). [[1]](diffhunk://#diff-1f1d98e789c5111c50869632c1387511e26f6c44ef359a358cb14ee6ca6ef31bR80-R146) [[2]](diffhunk://#diff-1f1d98e789c5111c50869632c1387511e26f6c44ef359a358cb14ee6ca6ef31bL88-R304)

### Testing Enhancements
* Added comprehensive test cases to validate the behavior of the new `--scratch` flag in all three modes (`collapsed`, `hidden`, `separated`) and edge cases like invalid modes (`internal/cmd/root_test.go`, `internal/dockerfile2dot/convert_test.go`). [[1]](diffhunk://#diff-6cb8801f5c168d1ee5c238a5dafdc893250f6bb23569d53d423c8a9d15121af1L495-R517) [[2]](diffhunk://#diff-da1cd2cc32fbc3ded7455550e185218b6095f1458abb49c64b850de36078388dL412-R412)
* Removed outdated test cases for the deprecated `--separate-scratch` flag and added cleanup logic for output files in tests (`internal/cmd/root_test.go`).

### Documentation Updates
* Updated the `README.md` to document the new `--scratch` flag and its modes (`README.md`).
* Improved testing guidelines in `.github/copilot-instructions.md` to emphasize comprehensive test coverage, including edge cases and error conditions (`.github/copilot-instructions.md`).

### Code Quality Improvements
* Refactored the `dockerfileToSimplifiedDockerfile` function by introducing helper functions (`processFromInstruction`, `processCopyInstruction`, etc.) for better maintainability and readability (`internal/dockerfile2dot/convert.go`).

These changes collectively improve the flexibility of scratch image handling, enhance test coverage, and maintain high code quality.